### PR TITLE
Update client.cpp

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -490,6 +490,8 @@ void HandleReplayerInput(SocketSet *c_sockset)
         switch (i) {
           case 0:
             // timeout
+            GetThreshold();
+            GetTargetFrame();
             match = TryMatchFrame();
             if (match) {
                 WaitForFrame = False;
@@ -522,6 +524,8 @@ void HandleReplayerInput(SocketSet *c_sockset)
             break;
           case 1:
             // socket can be read now
+	          GetThreshold();
+            GetTargetFrame();
             match = TryMatchFrame();
             if (match) {
                 WaitForFrame = False;


### PR DESCRIPTION
On reply, always captured frame is different from current one.
for some reason, the captured frame get corrupted and need to be re-read from hard disk with every check ( not only once as currently implemented)

my fix was to read it every time from the hard disk frame buffer file before comparing it with current frame. Specifically, in file client.cpp, function "HandleReplayerInput":

there are two calls for TryMatchFrame(), before each one of them you need to call GetTargetFrame()
